### PR TITLE
[builtin] add hashset Validate impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ updated throughout the repository.
 
 ## [Unreleased]
 
+## v0.1.1
+
+### Added
+- `std::containers::HashSet` now implements `Validate` along with the other stdlib containers.
+
 ## v0.1.0
 
 ### Added

--- a/validatron/src/lib.rs
+++ b/validatron/src/lib.rs
@@ -116,15 +116,14 @@ where
     }
 }
 
-// TODO: decide semantics and re-enable
-// impl<T, S> Validate for std::collections::HashSet<T, S>
-// where
-//     T: Validate,
-// {
-//     fn validate(&self) -> Result<()> {
-//         validate_seq(self)
-//     }
-// }
+impl<T, S> Validate for std::collections::HashSet<T, S>
+where
+    T: Validate,
+{
+    fn validate(&self) -> Result<()> {
+        validate_seq(self)
+    }
+}
 
 impl<T> Validate for std::collections::BTreeSet<T>
 where

--- a/validatron/tests/trait_impls.rs
+++ b/validatron/tests/trait_impls.rs
@@ -1,7 +1,7 @@
-use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, LinkedList, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet, LinkedList, VecDeque};
 use validatron::{Error, Location, Result, Validate};
 
-#[derive(PartialOrd, Ord, PartialEq, Eq)]
+#[derive(PartialOrd, Ord, PartialEq, Eq, Hash)]
 struct Dummy(bool);
 
 impl Validate for Dummy {
@@ -160,6 +160,18 @@ fn btreemap() {
             assert!(x.contains_key(&Location::Named("a different place".into())));
         }
     }
+}
+
+#[test]
+fn hashset() {
+    let mut data = HashSet::new();
+    assert!(data.validate().is_ok());
+
+    data.insert(Dummy(true));
+    assert!(data.validate().is_ok());
+
+    data.insert(Dummy(false));
+    assert!(data.validate().is_err());
 }
 
 #[test]

--- a/validatron_derive/src/lib.rs
+++ b/validatron_derive/src/lib.rs
@@ -107,12 +107,12 @@ fn build_type_validator(ast: &syn::DeriveInput) -> Vec<TokenStream> {
     for attr in ast.attrs.iter().filter(|x| x.path.is_ident("validatron")) {
         let meta = attr.parse_meta().unwrap();
 
-        if let syn::Meta::List(list) = meta {
+        use syn::{Meta, NestedMeta};
+
+        if let Meta::List(list) = meta {
             for item in list.nested.iter() {
-                if let syn::NestedMeta::Meta(meta) = item {
-                    if let syn::Meta::NameValue(mnv) = meta {
-                        type_validators.push(gen_type_check(&mnv));
-                    }
+                if let NestedMeta::Meta(Meta::NameValue(mnv)) = item {
+                    type_validators.push(gen_type_check(&mnv));
                 }
             }
         }


### PR DESCRIPTION
I originally didn't implement `Validate` for `HashSet` due to inconsistant ordering but on thinking about it some more I am happy with the caveats that come with it. Knowing that something is wrong is better than not knowing.