### PR TITLE
[derive] treat string literals as expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@ updated throughout the repository.
 
 ## [Unreleased]
 
+### Changed
+- Using a literal string in macro annotations will now be interpreted as an expression. This makes
+  it possible to inject values by running functions and using types such as `Some(42)` with
+  comparison operators. To inject string literals into macro attributes you will now now need to
+  escape the literal quotes like so: `#[validatron(equal = "\"Foo\"")]`
+
 ## v0.1.1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ updated throughout the repository.
 ## [Unreleased]
 
 ### Changed
-- Using a literal string in macro annotations will now be interpreted as an expression. This makes
+- *Breaking Change* Using a literal string in macro annotations will now be interpreted as an expression. This makes
   it possible to inject values by running functions and using types such as `Some(42)` with
   comparison operators. To inject string literals into macro attributes you will now now need to
   escape the literal quotes like so: `#[validatron(equal = "\"Foo\"")]`

--- a/README.md
+++ b/README.md
@@ -29,21 +29,21 @@ use validatron::Validate;
 struct MyStruct {
     #[validatron(min = 42)]
     a: i64,
-    #[validatron(equal = "hello world!")]
-    b: String,
+    #[validatron(max_len = 5)]
+    b: Vec<u32>,
 }
 
 fn main() {
     let good = MyStruct {
         a: 666,
-        b: "hello world!".into(),
+        b: vec![],
     };
 
     assert!(good.validate().is_ok());
 
     let bad = MyStruct {
         a: 1,
-        b: "so long and thanks for all the fish".into(),
+        b: vec![42; 25],
     };
 
     let result = bad.validate();

--- a/validatron/examples/basic.rs
+++ b/validatron/examples/basic.rs
@@ -4,21 +4,28 @@ use validatron::Validate;
 struct MyStruct {
     #[validatron(min = 42)]
     a: i64,
-    #[validatron(equal = "hello world!")]
-    b: String,
+
+    #[validatron(min_len = 10)]
+    b: Vec<i32>,
+
+    #[validatron(min = "42 + 12")]
+    c: i32,
 }
 
 fn main() {
     let good = MyStruct {
         a: 666,
-        b: "hello world!".into(),
+        b: vec![0; 15],
+        c: 666,
     };
 
+    println!("{:#?}", good.validate());
     assert!(good.validate().is_ok());
 
     let bad = MyStruct {
         a: 1,
-        b: "so long and thanks for all the fish".into(),
+        b: vec![],
+        c: 5,
     };
 
     let result = bad.validate();

--- a/validatron/examples/big_example.rs
+++ b/validatron/examples/big_example.rs
@@ -27,17 +27,22 @@ fn main() {
         #[validatron(min = 2., min = 3.)]
         #[validatron(max = 0., max = 2., equal = 3., equal = 1.)]
         out_a: f64,
+
         #[validatron]
         out_b: NestedValidateStruct,
+
         #[validatron(required)]
         out_c: Option<bool>,
+
         #[validatron]
         out_d: HashMap<&'static str, NestedValidateStruct>,
+
         #[validatron(function = "custom_str_compare")]
-        #[validatron(equal = "fluffy")]
         out_e: &'static str,
+
         #[validatron(function = "custom_str_compare")]
         out_e2: String,
+
         #[validatron]
         out_f: Vec<NestedValidateStruct>,
     }

--- a/validatron/src/lib.rs
+++ b/validatron/src/lib.rs
@@ -7,13 +7,13 @@
 //! struct MyStruct {
 //!     #[validatron(min = 42)]
 //!     a: i64,
-//!     #[validatron(equal = "hello world!")]
-//!     b: String,
+//!     #[validatron(max_len = 5)]
+//!     b: Vec<u32>,
 //! }
 //!
 //! let x = MyStruct {
 //!     a: 36,
-//!     b: "hello world!".into()
+//!     b: vec![]
 //! };
 //!
 //! x.validate().is_err();

--- a/validatron/tests/comp_validators.rs
+++ b/validatron/tests/comp_validators.rs
@@ -31,22 +31,27 @@ fn field_equal_validator() {
     #[derive(Validate)]
     struct Foo {
         #[validatron(equal = 10)]
+        #[validatron(equal = "10")]
+        #[validatron(equal = "9 + 1")]
         a: u64,
+
+        #[validatron(equal = "\"hello world!\"")]
+        b: String,
     }
 
-    assert_eq!(Foo { a: 10 }.validate().is_ok(), true);
-    assert_eq!(Foo { a: 20 }.validate().is_ok(), false);
-
-    #[derive(Validate)]
-    struct Bar {
-        #[validatron(equal = "hello world")]
-        a: &'static str,
-    }
-
-    assert_eq!(Bar { a: "hello world" }.validate().is_ok(), true);
     assert_eq!(
-        Bar {
-            a: "goodbye cruel world"
+        Foo {
+            a: 10,
+            b: "hello world!".into()
+        }
+        .validate()
+        .is_ok(),
+        true
+    );
+    assert_eq!(
+        Foo {
+            a: 20,
+            b: "".into()
         }
         .validate()
         .is_ok(),

--- a/validatron/tests/enum.rs
+++ b/validatron/tests/enum.rs
@@ -45,14 +45,14 @@ fn enum_new_type() {
     enum MyEnum {
         WithAttr(#[validatron] Dummy),
 
-        WithCustomAttr(#[validatron(equal = "hello")] String),
+        WithCustomAttr(#[validatron(equal = "32")] i64),
     }
 
     assert!(MyEnum::WithAttr(Dummy(true)).validate().is_ok());
     assert!(MyEnum::WithAttr(Dummy(false)).validate().is_err());
 
-    assert!(MyEnum::WithCustomAttr("hello".into()).validate().is_ok());
-    assert!(MyEnum::WithCustomAttr("".into()).validate().is_err());
+    assert!(MyEnum::WithCustomAttr(32).validate().is_ok());
+    assert!(MyEnum::WithCustomAttr(1).validate().is_err());
 }
 
 #[test]


### PR DESCRIPTION
Enables writing expressions such as: `#[validatron(min = "42 + 12")]`. It does make working with string literals a little less ergonomic but I would argue that good Rust code should use invariant types / enum's for handling those cases.