### PR TITLE
Add optional support for `indexmap`

### DIFF
--- a/validatron/Cargo.toml
+++ b/validatron/Cargo.toml
@@ -15,11 +15,13 @@ categories = ["encoding", "parsing"]
 [dependencies]
 thiserror = "1.0"
 validatron_derive = { path = "../validatron_derive", version = "0.2.1" }
-serde = {version="1.0", optional=true, features=["derive"]}
+serde = { version = "1.0", optional = true, features = ["derive"] }
+indexmap = { version = "1", optional = true }
 
 [features]
 default = ["use-serde"]
 
+use-indexmap = ["indexmap"]
 use-serde = ["serde"]
 
 [dev-dependencies]

--- a/validatron/src/lib.rs
+++ b/validatron/src/lib.rs
@@ -143,6 +143,33 @@ where
     }
 }
 
+#[cfg(feature = "use-indexmap")]
+impl<K, V> Validate for indexmap::IndexMap<K, V>
+where
+    K: std::fmt::Display,
+    V: Validate,
+{
+    fn validate(&self) -> Result<()> {
+        let mut eb = Error::build();
+
+        for (k, v) in self {
+            eb.try_at_named(k.to_string(), v.validate());
+        }
+
+        eb.build()
+    }
+}
+
+#[cfg(feature = "use-indexmap")]
+impl<T, S> Validate for indexmap::IndexSet<T, S>
+where
+    T: Validate,
+{
+    fn validate(&self) -> Result<()> {
+        validate_seq(self)
+    }
+}
+
 impl<T> Validate for Option<T>
 where
     T: Validate,


### PR DESCRIPTION
Add optional support for validating `IndexMap` and `IndexSet`.

It is activated with the `use-indexmap` feature flag.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>