### PR TITLE
Add opt-in indexmap2 support

### DIFF
--- a/validatron/Cargo.toml
+++ b/validatron/Cargo.toml
@@ -13,15 +13,17 @@ keywords = ["validation", "user-input"]
 categories = ["encoding", "parsing"]
 
 [dependencies]
+indexmap1 = {package = "indexmap", version = "1", optional = true}
+indexmap2 = {package = "indexmap", version = "2", optional = true}
+serde = {version = "1.0", optional = true, features = ["derive"]}
 thiserror = "1.0"
-validatron_derive = { path = "../validatron_derive", version = "0.5.0" }
-serde = { version = "1.0", optional = true, features = ["derive"] }
-indexmap = { version = "1", optional = true }
+validatron_derive = {path = "../validatron_derive", version = "0.5.0"}
 
 [features]
 default = ["use-serde"]
 
-use-indexmap = ["indexmap"]
+use-indexmap = ["dep:indexmap1"]
+use-indexmap2 = ["dep:indexmap2"]
 use-serde = ["serde"]
 
 [dev-dependencies]

--- a/validatron/src/lib.rs
+++ b/validatron/src/lib.rs
@@ -144,7 +144,24 @@ where
 }
 
 #[cfg(feature = "use-indexmap")]
-impl<K, V> Validate for indexmap::IndexMap<K, V>
+impl<K, V> Validate for indexmap1::IndexMap<K, V>
+where
+    K: std::fmt::Display,
+    V: Validate,
+{
+    fn validate(&self) -> Result<()> {
+        let mut eb = Error::build();
+
+        for (k, v) in self {
+            eb.try_at_named(k.to_string(), v.validate());
+        }
+
+        eb.build()
+    }
+}
+
+#[cfg(feature = "use-indexmap2")]
+impl<K, V> Validate for indexmap2::IndexMap<K, V>
 where
     K: std::fmt::Display,
     V: Validate,
@@ -161,7 +178,17 @@ where
 }
 
 #[cfg(feature = "use-indexmap")]
-impl<T, S> Validate for indexmap::IndexSet<T, S>
+impl<T, S> Validate for indexmap1::IndexSet<T, S>
+where
+    T: Validate,
+{
+    fn validate(&self) -> Result<()> {
+        validate_seq(self)
+    }
+}
+
+#[cfg(feature = "use-indexmap2")]
+impl<T, S> Validate for indexmap2::IndexSet<T, S>
 where
     T: Validate,
 {


### PR DESCRIPTION
Add support for indexmap v2 behind the `use-indexmap2` feature flag.

`use-indexmap` feature still works as before.